### PR TITLE
Bump Kubernetes versions to pick up latest releases

### DIFF
--- a/pkg/helm/values/eks.go
+++ b/pkg/helm/values/eks.go
@@ -9,24 +9,34 @@ import (
 
 var EKSAPIVersionMap = map[string]string{
 	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.24.6-eks-1-24-3",
+	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.23.13-eks-1-23-8",
+	"1.22": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.22.15-eks-1-22-13",
+	"1.21": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.21.14-eks-1-21-21",
+	"1.20": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.20.15-eks-1-20-22",
 }
 
 var EKSControllerVersionMap = map[string]string{
-	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.23.7-eks-1-23-4",
-	"1.21": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.21.13-eks-1-21-17",
-	"1.20": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.20.15-eks-1-20-19",
+	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.23.7-eks-1-23-4",
+	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.23.13-eks-1-23-8",
+	"1.22": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.22.15-eks-1-22-13",
+	"1.21": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.21.14-eks-1-21-21",
+	"1.20": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.20.15-eks-1-20-22",
 }
 
 var EKSEtcdVersionMap = map[string]string{
-	"1.23": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.4-eks-1-23-4",
-	"1.21": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.18-eks-1-21-17",
-	"1.20": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.18-eks-1-20-19",
+	"1.24": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.4-eks-1-24-3",
+	"1.23": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.4-eks-1-23-8",
+	"1.22": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.4-eks-1-22-13",
+	"1.21": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.21-eks-1-21-21",
+	"1.20": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.21-eks-1-20-22",
 }
 
 var EKSCoreDNSVersionMap = map[string]string{
-	"1.23": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-23-4",
-	"1.21": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.4-eks-1-21-17",
-	"1.20": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.3-eks-1-20-19",
+	"1.24": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-24-3",
+	"1.23": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-23-8",
+	"1.22": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-22-13",
+	"1.21": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.4-eks-1-21-21",
+	"1.20": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.3-eks-1-20-22",
 }
 
 func getDefaultEKSReleaseValues(chartOptions *helm.ChartOptions, log log.Logger) (string, error) {

--- a/pkg/helm/values/eks.go
+++ b/pkg/helm/values/eks.go
@@ -8,9 +8,7 @@ import (
 )
 
 var EKSAPIVersionMap = map[string]string{
-	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.23.7-eks-1-23-4",
-	"1.21": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.21.13-eks-1-21-17",
-	"1.20": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.20.15-eks-1-20-19",
+	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.24.6-eks-1-24-3",
 }
 
 var EKSControllerVersionMap = map[string]string{
@@ -43,12 +41,12 @@ func getDefaultEKSReleaseValues(chartOptions *helm.ChartOptions, log log.Logger)
 	etcdImage := EKSEtcdVersionMap[serverVersionString]
 	corednsImage, ok := EKSCoreDNSVersionMap[serverVersionString]
 	if !ok {
-		if serverMinorInt > 23 {
-			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.23", serverVersionString)
-			apiImage = EKSAPIVersionMap["1.23"]
-			controllerImage = EKSControllerVersionMap["1.23"]
-			etcdImage = EKSEtcdVersionMap["1.23"]
-			corednsImage = EKSCoreDNSVersionMap["1.23"]
+		if serverMinorInt > 24 {
+			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.24", serverVersionString)
+			apiImage = EKSAPIVersionMap["1.24"]
+			controllerImage = EKSControllerVersionMap["1.24"]
+			etcdImage = EKSEtcdVersionMap["1.24"]
+			corednsImage = EKSCoreDNSVersionMap["1.24"]
 		} else {
 			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.20", serverVersionString)
 			apiImage = EKSAPIVersionMap["1.20"]

--- a/pkg/helm/values/k0s.go
+++ b/pkg/helm/values/k0s.go
@@ -9,6 +9,9 @@ import (
 
 var K0SVersionMap = map[string]string{
 	"1.25": "k0sproject/k0s:v1.25.3-k0s.0",
+	"1.24": "k0sproject/k0s:v1.24.7-k0s.0",
+	"1.23": "k0sproject/k0s:v1.23.13-k0s.0",
+	"1.22": "k0sproject/k0s:v1.22.15-k0s.0",
 }
 
 func getDefaultK0SReleaseValues(chartOptions *helm.ChartOptions, log log.Logger) (string, error) {

--- a/pkg/helm/values/k0s.go
+++ b/pkg/helm/values/k0s.go
@@ -8,9 +8,7 @@ import (
 )
 
 var K0SVersionMap = map[string]string{
-	"1.24": "k0sproject/k0s:v1.24.3-k0s.0",
-	"1.23": "k0sproject/k0s:v1.23.9-k0s.0",
-	"1.22": "k0sproject/k0s:v1.22.12-k0s.0",
+	"1.25": "k0sproject/k0s:v1.25.3-k0s.0",
 }
 
 func getDefaultK0SReleaseValues(chartOptions *helm.ChartOptions, log log.Logger) (string, error) {
@@ -22,9 +20,9 @@ func getDefaultK0SReleaseValues(chartOptions *helm.ChartOptions, log log.Logger)
 
 	image, ok := K0SVersionMap[serverVersionString]
 	if !ok {
-		if serverMinorInt > 24 {
-			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.24", serverVersionString)
-			image = K0SVersionMap["1.24"]
+		if serverMinorInt > 25 {
+			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.25", serverVersionString)
+			image = K0SVersionMap["1.25"]
 		} else {
 			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.22", serverVersionString)
 			image = K0SVersionMap["1.22"]

--- a/pkg/helm/values/k3s.go
+++ b/pkg/helm/values/k3s.go
@@ -13,6 +13,9 @@ import (
 
 var K3SVersionMap = map[string]string{
 	"1.25": "rancher/k3s:v1.25.3-k3s1",
+	"1.24": "rancher/k3s:v1.24.7-k3s1",
+	"1.23": "rancher/k3s:v1.23.13-k3s1",
+	"1.22": "rancher/k3s:v1.22.15-k3s1",
 	"1.21": "rancher/k3s:v1.21.14-k3s1",
 	"1.20": "rancher/k3s:v1.20.15-k3s1",
 	"1.19": "rancher/k3s:v1.19.16-k3s1",

--- a/pkg/helm/values/k3s.go
+++ b/pkg/helm/values/k3s.go
@@ -12,9 +12,7 @@ import (
 )
 
 var K3SVersionMap = map[string]string{
-	"1.24": "rancher/k3s:v1.24.3-k3s1",
-	"1.23": "rancher/k3s:v1.23.9-k3s1",
-	"1.22": "rancher/k3s:v1.22.12-k3s1",
+	"1.25": "rancher/k3s:v1.25.3-k3s1",
 	"1.21": "rancher/k3s:v1.21.14-k3s1",
 	"1.20": "rancher/k3s:v1.20.15-k3s1",
 	"1.19": "rancher/k3s:v1.19.16-k3s1",
@@ -58,10 +56,10 @@ func getDefaultK3SReleaseValues(chartOptions *helm.ChartOptions, log log.Logger)
 		var ok bool
 		image, ok = K3SVersionMap[serverVersionString]
 		if !ok {
-			if serverMinorInt > 24 {
-				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.24", serverVersionString)
-				image = K3SVersionMap["1.24"]
-				serverVersionString = "1.24"
+			if serverMinorInt > 25 {
+				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.25", serverVersionString)
+				image = K3SVersionMap["1.25"]
+				serverVersionString = "1.25"
 			} else {
 				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.16", serverVersionString)
 				image = K3SVersionMap["1.16"]

--- a/pkg/helm/values/k8s.go
+++ b/pkg/helm/values/k8s.go
@@ -8,30 +8,34 @@ import (
 )
 
 var K8SAPIVersionMap = map[string]string{
-	"1.24": "registry.k8s.io/kube-apiserver:v1.24.3",
-	"1.23": "registry.k8s.io/kube-apiserver:v1.23.9",
-	"1.22": "registry.k8s.io/kube-apiserver:v1.22.12",
+	"1.25": "registry.k8s.io/kube-apiserver:v1.25.4",
+	"1.24": "registry.k8s.io/kube-apiserver:v1.24.8",
+	"1.23": "registry.k8s.io/kube-apiserver:v1.23.14",
+	"1.22": "registry.k8s.io/kube-apiserver:v1.22.16",
 	"1.21": "registry.k8s.io/kube-apiserver:v1.21.14",
 	"1.20": "registry.k8s.io/kube-apiserver:v1.20.15",
 }
 
 var K8SControllerVersionMap = map[string]string{
-	"1.24": "registry.k8s.io/kube-controller-manager:v1.24.3",
-	"1.23": "registry.k8s.io/kube-controller-manager:v1.23.9",
-	"1.22": "registry.k8s.io/kube-controller-manager:v1.22.12",
+	"1.25": "registry.k8s.io/kube-controller-manager:v1.25.4",
+	"1.24": "registry.k8s.io/kube-controller-manager:v1.24.8",
+	"1.23": "registry.k8s.io/kube-controller-manager:v1.23.14",
+	"1.22": "registry.k8s.io/kube-controller-manager:v1.22.16",
 	"1.21": "registry.k8s.io/kube-controller-manager:v1.21.14",
 	"1.20": "registry.k8s.io/kube-controller-manager:v1.20.15",
 }
 
 var K8SSchedulerVersionMap = map[string]string{
-	"1.24": "registry.k8s.io/kube-scheduler:v1.24.3",
-	"1.23": "registry.k8s.io/kube-scheduler:v1.23.9",
-	"1.22": "registry.k8s.io/kube-scheduler:v1.22.12",
+	"1.25": "registry.k8s.io/kube-scheduler:v1.25.4",
+	"1.24": "registry.k8s.io/kube-scheduler:v1.24.8",
+	"1.23": "registry.k8s.io/kube-scheduler:v1.23.14",
+	"1.22": "registry.k8s.io/kube-scheduler:v1.22.16",
 	"1.21": "registry.k8s.io/kube-scheduler:v1.21.14",
 	"1.20": "registry.k8s.io/kube-scheduler:v1.20.15",
 }
 
 var K8SEtcdVersionMap = map[string]string{
+	"1.25": "registry.k8s.io/etcd:3.5.5-0",
 	"1.24": "registry.k8s.io/etcd:3.5.1-0",
 	"1.23": "registry.k8s.io/etcd:3.5.1-0",
 	"1.22": "registry.k8s.io/etcd:3.5.1-0",
@@ -51,12 +55,12 @@ func getDefaultK8SReleaseValues(chartOptions *helm.ChartOptions, log log.Logger)
 	schedulerImage := K8SSchedulerVersionMap[serverVersionString]
 	etcdImage, ok := K8SEtcdVersionMap[serverVersionString]
 	if !ok {
-		if serverMinorInt > 24 {
-			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.24", serverVersionString)
-			apiImage = K8SAPIVersionMap["1.24"]
-			controllerImage = K8SControllerVersionMap["1.24"]
-			schedulerImage = K8SSchedulerVersionMap["1.24"]
-			etcdImage = K8SEtcdVersionMap["1.24"]
+		if serverMinorInt > 25 {
+			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.25", serverVersionString)
+			apiImage = K8SAPIVersionMap["1.25"]
+			controllerImage = K8SControllerVersionMap["1.25"]
+			schedulerImage = K8SSchedulerVersionMap["1.25"]
+			etcdImage = K8SEtcdVersionMap["1.25"]
 		} else {
 			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.20", serverVersionString)
 			apiImage = K8SAPIVersionMap["1.20"]


### PR DESCRIPTION
**What:**
- Add k8s 1.25 and bump k8s images to fix important CVEs
- Add k3s and k0s v1.25
- Add eks v1.24
- Bump k3s, k0s, eks to latest builds

**Why:**
Besides offering the latest release (1.25, or 1.24 for EKS), we want to include recent security fixes for important(_Medium_) CVEs (CVE-2022-3294, CVE-2022-3162) where possible (only k8s right now).