### PR TITLE
Bump image versions to latest stable releases for all distros

### DIFF
--- a/pkg/helm/values/eks.go
+++ b/pkg/helm/values/eks.go
@@ -8,34 +8,34 @@ import (
 )
 
 var EKSAPIVersionMap = map[string]string{
-	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.24.6-eks-1-24-3",
-	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.23.13-eks-1-23-8",
-	"1.22": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.22.15-eks-1-22-13",
-	"1.21": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.21.14-eks-1-21-21",
+	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.24.9-eks-1-24-7",
+	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.23.15-eks-1-23-12",
+	"1.22": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.22.17-eks-1-22-17",
+	"1.21": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.21.14-eks-1-21-24",
 	"1.20": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.20.15-eks-1-20-22",
 }
 
 var EKSControllerVersionMap = map[string]string{
-	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.23.7-eks-1-23-4",
-	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.23.13-eks-1-23-8",
-	"1.22": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.22.15-eks-1-22-13",
-	"1.21": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.21.14-eks-1-21-21",
+	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.24.9-eks-1-24-7",
+	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.23.15-eks-1-23-12",
+	"1.22": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.22.17-eks-1-22-17",
+	"1.21": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.21.14-eks-1-21-24",
 	"1.20": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.20.15-eks-1-20-22",
 }
 
 var EKSEtcdVersionMap = map[string]string{
-	"1.24": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.4-eks-1-24-3",
-	"1.23": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.4-eks-1-23-8",
-	"1.22": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.4-eks-1-22-13",
-	"1.21": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.21-eks-1-21-21",
+	"1.24": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.6-eks-1-24-7",
+	"1.23": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.6-eks-1-23-12",
+	"1.22": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.6-eks-1-22-17",
+	"1.21": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.21-eks-1-21-24",
 	"1.20": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.4.21-eks-1-20-22",
 }
 
 var EKSCoreDNSVersionMap = map[string]string{
-	"1.24": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-24-3",
-	"1.23": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-23-8",
-	"1.22": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-22-13",
-	"1.21": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.4-eks-1-21-21",
+	"1.24": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-24-7",
+	"1.23": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-23-12",
+	"1.22": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-22-17",
+	"1.21": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.4-eks-1-21-24",
 	"1.20": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.3-eks-1-20-22",
 }
 

--- a/pkg/helm/values/k0s.go
+++ b/pkg/helm/values/k0s.go
@@ -8,10 +8,11 @@ import (
 )
 
 var K0SVersionMap = map[string]string{
-	"1.25": "k0sproject/k0s:v1.25.3-k0s.0",
-	"1.24": "k0sproject/k0s:v1.24.7-k0s.0",
-	"1.23": "k0sproject/k0s:v1.23.13-k0s.0",
-	"1.22": "k0sproject/k0s:v1.22.15-k0s.0",
+	"1.26": "k0sproject/k0s:v1.26.0-k0s.0",
+	"1.25": "k0sproject/k0s:v1.25.5-k0s.0",
+	"1.24": "k0sproject/k0s:v1.24.9-k0s.0",
+	"1.23": "k0sproject/k0s:v1.23.15-k0s.0",
+	"1.22": "k0sproject/k0s:v1.22.17-k0s.0",
 }
 
 func getDefaultK0SReleaseValues(chartOptions *helm.ChartOptions, log log.Logger) (string, error) {
@@ -23,9 +24,9 @@ func getDefaultK0SReleaseValues(chartOptions *helm.ChartOptions, log log.Logger)
 
 	image, ok := K0SVersionMap[serverVersionString]
 	if !ok {
-		if serverMinorInt > 25 {
-			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.25", serverVersionString)
-			image = K0SVersionMap["1.25"]
+		if serverMinorInt > 26 {
+			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.26", serverVersionString)
+			image = K0SVersionMap["1.26"]
 		} else {
 			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.22", serverVersionString)
 			image = K0SVersionMap["1.22"]

--- a/pkg/helm/values/k3s.go
+++ b/pkg/helm/values/k3s.go
@@ -12,10 +12,11 @@ import (
 )
 
 var K3SVersionMap = map[string]string{
-	"1.25": "rancher/k3s:v1.25.3-k3s1",
-	"1.24": "rancher/k3s:v1.24.7-k3s1",
-	"1.23": "rancher/k3s:v1.23.13-k3s1",
-	"1.22": "rancher/k3s:v1.22.15-k3s1",
+	"1.26": "rancher/k3s:v1.26.0-k3s1",
+	"1.25": "rancher/k3s:v1.25.5-k3s1",
+	"1.24": "rancher/k3s:v1.24.9-k3s1",
+	"1.23": "rancher/k3s:v1.23.15-k3s1",
+	"1.22": "rancher/k3s:v1.22.17-k3s1",
 	"1.21": "rancher/k3s:v1.21.14-k3s1",
 	"1.20": "rancher/k3s:v1.20.15-k3s1",
 	"1.19": "rancher/k3s:v1.19.16-k3s1",
@@ -59,10 +60,10 @@ func getDefaultK3SReleaseValues(chartOptions *helm.ChartOptions, log log.Logger)
 		var ok bool
 		image, ok = K3SVersionMap[serverVersionString]
 		if !ok {
-			if serverMinorInt > 25 {
-				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.25", serverVersionString)
-				image = K3SVersionMap["1.25"]
-				serverVersionString = "1.25"
+			if serverMinorInt > 26 {
+				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.26", serverVersionString)
+				image = K3SVersionMap["1.26"]
+				serverVersionString = "1.26"
 			} else {
 				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.16", serverVersionString)
 				image = K3SVersionMap["1.16"]

--- a/pkg/helm/values/k8s.go
+++ b/pkg/helm/values/k8s.go
@@ -8,30 +8,30 @@ import (
 )
 
 var K8SAPIVersionMap = map[string]string{
-	"1.26": "registry.k8s.io/kube-apiserver:v1.26.0",
-	"1.25": "registry.k8s.io/kube-apiserver:v1.25.5",
-	"1.24": "registry.k8s.io/kube-apiserver:v1.24.9",
-	"1.23": "registry.k8s.io/kube-apiserver:v1.23.15",
+	"1.26": "registry.k8s.io/kube-apiserver:v1.26.1",
+	"1.25": "registry.k8s.io/kube-apiserver:v1.25.6",
+	"1.24": "registry.k8s.io/kube-apiserver:v1.24.10",
+	"1.23": "registry.k8s.io/kube-apiserver:v1.23.16",
 	"1.22": "registry.k8s.io/kube-apiserver:v1.22.17",
 	"1.21": "registry.k8s.io/kube-apiserver:v1.21.14",
 	"1.20": "registry.k8s.io/kube-apiserver:v1.20.15",
 }
 
 var K8SControllerVersionMap = map[string]string{
-	"1.26": "registry.k8s.io/kube-controller-manager:v1.26.0",
-	"1.25": "registry.k8s.io/kube-controller-manager:v1.25.5",
-	"1.24": "registry.k8s.io/kube-controller-manager:v1.24.9",
-	"1.23": "registry.k8s.io/kube-controller-manager:v1.23.15",
+	"1.26": "registry.k8s.io/kube-controller-manager:v1.26.1",
+	"1.25": "registry.k8s.io/kube-controller-manager:v1.25.6",
+	"1.24": "registry.k8s.io/kube-controller-manager:v1.24.10",
+	"1.23": "registry.k8s.io/kube-controller-manager:v1.23.16",
 	"1.22": "registry.k8s.io/kube-controller-manager:v1.22.17",
 	"1.21": "registry.k8s.io/kube-controller-manager:v1.21.14",
 	"1.20": "registry.k8s.io/kube-controller-manager:v1.20.15",
 }
 
 var K8SSchedulerVersionMap = map[string]string{
-	"1.26": "registry.k8s.io/kube-scheduler:v1.26.0",
-	"1.25": "registry.k8s.io/kube-scheduler:v1.25.5",
-	"1.24": "registry.k8s.io/kube-scheduler:v1.24.9",
-	"1.23": "registry.k8s.io/kube-scheduler:v1.23.15",
+	"1.26": "registry.k8s.io/kube-scheduler:v1.26.1",
+	"1.25": "registry.k8s.io/kube-scheduler:v1.25.6",
+	"1.24": "registry.k8s.io/kube-scheduler:v1.24.10",
+	"1.23": "registry.k8s.io/kube-scheduler:v1.23.16",
 	"1.22": "registry.k8s.io/kube-scheduler:v1.22.17",
 	"1.21": "registry.k8s.io/kube-scheduler:v1.21.14",
 	"1.20": "registry.k8s.io/kube-scheduler:v1.20.15",


### PR DESCRIPTION
- Added images for v1.26 for all supported distros
- Bumped versions to latest stable releases for all previous kubernetes versions