### PR TITLE
feat: add telemetry chart options

### DIFF
--- a/pkg/helm/types.go
+++ b/pkg/helm/types.go
@@ -9,18 +9,21 @@ const (
 
 // ChartOptions holds the chart options
 type ChartOptions struct {
-	ChartName          string
-	ChartRepo          string
-	ChartVersion       string
-	CIDR               string
-	CreateClusterRole  bool
-	DisableIngressSync bool
-	Expose             bool
-	NodePort           bool
-	SyncNodes          bool
-	K3SImage           string
-	Isolate            bool
-	KubernetesVersion  Version
+	ChartName           string
+	ChartRepo           string
+	ChartVersion        string
+	CIDR                string
+	CreateClusterRole   bool
+	DisableIngressSync  bool
+	Expose              bool
+	NodePort            bool
+	SyncNodes           bool
+	K3SImage            string
+	Isolate             bool
+	KubernetesVersion   Version
+	DisableTelemetry    bool
+	InstanceCreatorType string
+	InstanceCreatorUID  string
 }
 
 type Version struct {

--- a/pkg/helm/values/k3s.go
+++ b/pkg/helm/values/k3s.go
@@ -135,6 +135,20 @@ isolation:
   enabled: true`
 	}
 
+	if chartOptions.DisableTelemetry {
+		values += `
+telemetry:
+  disabled: "true"`
+	} else if chartOptions.InstanceCreatorType != "" || chartOptions.InstanceCreatorUID != "" {
+		values += `
+telemetry:
+  disabled: "false"
+  instanceCreator: "##INSTANCE_CREATOR##"
+  instanceCreatorUID: "##INSTANCE_CREATOR_UID##"`
+		values = strings.ReplaceAll(values, "##INSTANCE_CREATOR##", chartOptions.InstanceCreatorType)
+		values = strings.ReplaceAll(values, "##INSTANCE_CREATOR_UID##", chartOptions.InstanceCreatorUID)
+	}
+
 	values = strings.TrimSpace(values)
 	return values, nil
 }


### PR DESCRIPTION
These are the related helm chart changes that will be in the vcluster PR:
```
telemetry:
  disabled: "false"
  instanceCreatorType: "helm"
  instanceCreatorUID: ""
```
```
          - name: VCLUSTER_TELEMETRY_DISABLED
            value: {{ .Values.telemetry.disabled | quote }}
          - name: VCLUSTER_INSTANCE_CREATOR_TYPE
            value: {{ .Values.telemetry.instanceCreatorType | quote }}
          - name: VCLUSTER_INSTANCE_CREATOR_UID
            value: {{ .Values.telemetry.instanceCreatorUID | quote }}
```