### PR TITLE
Bump patch versions to the latest one

### DIFF
--- a/pkg/helm/values/eks.go
+++ b/pkg/helm/values/eks.go
@@ -9,38 +9,38 @@ import (
 
 var EKSAPIVersionMap = map[string]string{
 	"1.27": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.27.1-eks-1-27-4",
-	"1.26": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.26.4-eks-1-26-9",
-	"1.25": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.25.9-eks-1-25-13",
-	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.24.13-eks-1-24-17",
-	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.23.17-eks-1-23-22",
-	"1.22": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.22.17-eks-1-22-27",
+	"1.26": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.26.4-eks-1-26-10",
+	"1.25": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.25.9-eks-1-25-14",
+	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.24.13-eks-1-24-18",
+	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.23.17-eks-1-23-23",
+	"1.22": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.22.17-eks-1-22-28",
 }
 
 var EKSControllerVersionMap = map[string]string{
 	"1.27": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.27.1-eks-1-27-4",
-	"1.26": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.26.4-eks-1-26-9",
-	"1.25": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.25.9-eks-1-25-13",
-	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.24.13-eks-1-24-17",
-	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.23.17-eks-1-23-22",
-	"1.22": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.22.17-eks-1-22-27",
+	"1.26": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.26.4-eks-1-26-10",
+	"1.25": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.25.9-eks-1-25-14",
+	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.24.13-eks-1-24-18",
+	"1.23": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.23.17-eks-1-23-23",
+	"1.22": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.22.17-eks-1-22-28",
 }
 
 var EKSEtcdVersionMap = map[string]string{
 	"1.27": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-27-4",
-	"1.26": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-26-9",
-	"1.25": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-25-13",
-	"1.24": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-24-17",
-	"1.23": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-23-22",
-	"1.22": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-22-27",
+	"1.26": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-26-10",
+	"1.25": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-25-14",
+	"1.24": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-24-18",
+	"1.23": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-23-23",
+	"1.22": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-22-28",
 }
 
 var EKSCoreDNSVersionMap = map[string]string{
 	"1.27": "public.ecr.aws/eks-distro/coredns/coredns:v1.10.1-eks-1-27-4",
-	"1.26": "public.ecr.aws/eks-distro/coredns/coredns:v1.9.3-eks-1-26-9",
-	"1.25": "public.ecr.aws/eks-distro/coredns/coredns:v1.9.3-eks-1-25-13",
-	"1.24": "public.ecr.aws/eks-distro/coredns/coredns:v1.9.3-eks-1-24-17",
-	"1.23": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-23-22",
-	"1.22": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-22-27",
+	"1.26": "public.ecr.aws/eks-distro/coredns/coredns:v1.9.3-eks-1-26-10",
+	"1.25": "public.ecr.aws/eks-distro/coredns/coredns:v1.9.3-eks-1-25-14",
+	"1.24": "public.ecr.aws/eks-distro/coredns/coredns:v1.9.3-eks-1-24-18",
+	"1.23": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-23-23",
+	"1.22": "public.ecr.aws/eks-distro/coredns/coredns:v1.8.7-eks-1-22-28",
 }
 
 func getDefaultEKSReleaseValues(chartOptions *helm.ChartOptions, log log.SimpleLogger) (string, error) {

--- a/pkg/helm/values/eks.go
+++ b/pkg/helm/values/eks.go
@@ -8,7 +8,7 @@ import (
 )
 
 var EKSAPIVersionMap = map[string]string{
-	"1.27": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.27.1-eks-1-27-3",
+	"1.27": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.27.1-eks-1-27-4",
 	"1.26": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.26.4-eks-1-26-9",
 	"1.25": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.25.9-eks-1-25-13",
 	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-apiserver:v1.24.13-eks-1-24-17",
@@ -17,7 +17,7 @@ var EKSAPIVersionMap = map[string]string{
 }
 
 var EKSControllerVersionMap = map[string]string{
-	"1.27": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.27.1-eks-1-27-3",
+	"1.27": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.27.1-eks-1-27-4",
 	"1.26": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.26.4-eks-1-26-9",
 	"1.25": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.25.9-eks-1-25-13",
 	"1.24": "public.ecr.aws/eks-distro/kubernetes/kube-controller-manager:v1.24.13-eks-1-24-17",
@@ -26,7 +26,7 @@ var EKSControllerVersionMap = map[string]string{
 }
 
 var EKSEtcdVersionMap = map[string]string{
-	"1.27": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-27-3",
+	"1.27": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-27-4",
 	"1.26": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-26-9",
 	"1.25": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-25-13",
 	"1.24": "public.ecr.aws/eks-distro/etcd-io/etcd:v3.5.7-eks-1-24-17",
@@ -35,7 +35,7 @@ var EKSEtcdVersionMap = map[string]string{
 }
 
 var EKSCoreDNSVersionMap = map[string]string{
-	"1.27": "public.ecr.aws/eks-distro/coredns/coredns:v1.10.1-eks-1-27-3",
+	"1.27": "public.ecr.aws/eks-distro/coredns/coredns:v1.10.1-eks-1-27-4",
 	"1.26": "public.ecr.aws/eks-distro/coredns/coredns:v1.9.3-eks-1-26-9",
 	"1.25": "public.ecr.aws/eks-distro/coredns/coredns:v1.9.3-eks-1-25-13",
 	"1.24": "public.ecr.aws/eks-distro/coredns/coredns:v1.9.3-eks-1-24-17",
@@ -55,12 +55,12 @@ func getDefaultEKSReleaseValues(chartOptions *helm.ChartOptions, log log.SimpleL
 	etcdImage := EKSEtcdVersionMap[serverVersionString]
 	corednsImage, ok := EKSCoreDNSVersionMap[serverVersionString]
 	if !ok {
-		if serverMinorInt > 26 {
-			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.26", serverVersionString)
-			apiImage = EKSAPIVersionMap["1.26"]
-			controllerImage = EKSControllerVersionMap["1.26"]
-			etcdImage = EKSEtcdVersionMap["1.26"]
-			corednsImage = EKSCoreDNSVersionMap["1.26"]
+		if serverMinorInt > 27 {
+			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.27", serverVersionString)
+			apiImage = EKSAPIVersionMap["1.27"]
+			controllerImage = EKSControllerVersionMap["1.27"]
+			etcdImage = EKSEtcdVersionMap["1.27"]
+			corednsImage = EKSCoreDNSVersionMap["1.27"]
 		} else {
 			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.22", serverVersionString)
 			apiImage = EKSAPIVersionMap["1.22"]

--- a/pkg/helm/values/k0s.go
+++ b/pkg/helm/values/k0s.go
@@ -8,7 +8,7 @@ import (
 )
 
 var K0SVersionMap = map[string]string{
-	"1.27": "k0sproject/k0s:v1.27.1-k0s.0",
+	"1.27": "k0sproject/k0s:v1.27.2-k0s.0",
 	"1.26": "k0sproject/k0s:v1.26.4-k0s.0",
 	"1.25": "k0sproject/k0s:v1.25.8-k0s.1",
 	"1.24": "k0sproject/k0s:v1.24.12-k0s.1",
@@ -24,9 +24,9 @@ func getDefaultK0SReleaseValues(chartOptions *helm.ChartOptions, log log.SimpleL
 
 	image, ok := K0SVersionMap[serverVersionString]
 	if !ok {
-		if serverMinorInt > 26 {
-			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.26", serverVersionString)
-			image = K0SVersionMap["1.26"]
+		if serverMinorInt > 27 {
+			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.27", serverVersionString)
+			image = K0SVersionMap["1.27"]
 		} else {
 			log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.23", serverVersionString)
 			image = K0SVersionMap["1.23"]

--- a/pkg/helm/values/k0s.go
+++ b/pkg/helm/values/k0s.go
@@ -9,9 +9,9 @@ import (
 
 var K0SVersionMap = map[string]string{
 	"1.27": "k0sproject/k0s:v1.27.2-k0s.0",
-	"1.26": "k0sproject/k0s:v1.26.4-k0s.0",
-	"1.25": "k0sproject/k0s:v1.25.8-k0s.1",
-	"1.24": "k0sproject/k0s:v1.24.12-k0s.1",
+	"1.26": "k0sproject/k0s:v1.26.5-k0s.0",
+	"1.25": "k0sproject/k0s:v1.25.10-k0s.0",
+	"1.24": "k0sproject/k0s:v1.24.14-k0s.0",
 	"1.23": "k0sproject/k0s:v1.23.15-k0s.0",
 }
 

--- a/pkg/helm/values/k3s.go
+++ b/pkg/helm/values/k3s.go
@@ -11,7 +11,7 @@ import (
 )
 
 var K3SVersionMap = map[string]string{
-	"1.27": "rancher/k3s:v1.27.1-k3s1",
+	"1.27": "rancher/k3s:v1.27.2-k3s1",
 	"1.26": "rancher/k3s:v1.26.4-k3s1",
 	"1.25": "rancher/k3s:v1.25.9-k3s1",
 	"1.24": "rancher/k3s:v1.24.13-k3s1",
@@ -38,9 +38,9 @@ func getDefaultK3SReleaseValues(chartOptions *helm.ChartOptions, log log.SimpleL
 		var ok bool
 		image, ok = K3SVersionMap[serverVersionString]
 		if !ok {
-			if serverMinorInt > 26 {
-				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.26", serverVersionString)
-				image = K3SVersionMap["1.26"]
+			if serverMinorInt > 27 {
+				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.27", serverVersionString)
+				image = K3SVersionMap["1.27"]
 			} else {
 				log.Infof("officially unsupported host server version %s, will fallback to virtual cluster version v1.23", serverVersionString)
 				image = K3SVersionMap["1.23"]

--- a/pkg/helm/values/k3s.go
+++ b/pkg/helm/values/k3s.go
@@ -12,9 +12,9 @@ import (
 
 var K3SVersionMap = map[string]string{
 	"1.27": "rancher/k3s:v1.27.2-k3s1",
-	"1.26": "rancher/k3s:v1.26.4-k3s1",
-	"1.25": "rancher/k3s:v1.25.9-k3s1",
-	"1.24": "rancher/k3s:v1.24.13-k3s1",
+	"1.26": "rancher/k3s:v1.26.5-k3s1",
+	"1.25": "rancher/k3s:v1.25.10-k3s1",
+	"1.24": "rancher/k3s:v1.24.14-k3s1",
 	"1.23": "rancher/k3s:v1.23.17-k3s1",
 }
 


### PR DESCRIPTION
Add official support for the k8s 1.27 for eks/k0s/k3s + bump all patch versions to the latest.